### PR TITLE
Update denoinit to Deno 0.4.0

### DIFF
--- a/denoinit/README.md
+++ b/denoinit/README.md
@@ -16,7 +16,7 @@
 
 ```sh
 cd ~/to/your/deno_project
-deno https://denopkg.com/syumai/deno-libs/denoinit/denoinit.ts --allow-write --allow-env --allow-run
+deno --allow-write --allow-env --allow-run https://denopkg.com/syumai/deno-libs/denoinit/denoinit.ts
 ```
 
 ### Install

--- a/denoinit/denoinit.ts
+++ b/denoinit/denoinit.ts
@@ -43,7 +43,7 @@ async function main() {
   copy(tsconfigFile, config);
   console.log('tsconfig.json successfully generated!');
 
-  const types = run({ args: ['deno', '--types'], stdout: 'piped' });
+  const types = run({ args: ['deno', 'types'], stdout: 'piped' });
   const out = await types.output();
   await writeFile(`${HOME}/.deno/deno.d.ts`, out);
   types.close();


### PR DESCRIPTION
Fixes the following output

```
error: Found argument 'https://denopkg.com/syumai/deno-libs/denoinit/denoinit.ts' which wasn't expected, or isn't valid in this context

USAGE:
    deno [FLAGS] [OPTIONS] [SUBCOMMAND]

For more information try --help
```