### PR TITLE
Update installation instructions

### DIFF
--- a/denoinit/README.md
+++ b/denoinit/README.md
@@ -21,11 +21,8 @@ deno --allow-write --allow-env --allow-run https://denopkg.com/syumai/deno-libs/
 
 ### Install
 
-- With [denoget](https://github.com/syumai/denoget)
-
 ```sh
-denoget https://denopkg.com/syumai/deno-libs/denoinit/denoinit.ts
-denoinit
+deno install denoinit https://denopkg.com/syumai/deno-libs/denoinit/denoinit.ts --allow-write --allow-env --allow-run
 ```
 
 ## Example output


### PR DESCRIPTION
due to deprecation of `denoget`

Please note: command doesn't work atm because of the issue with `std/io/util.ts` dep (but it's fixed in #17)